### PR TITLE
Fix minio server start for Kasten

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_kasten/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kasten/tasks/pre_workload.yml
@@ -53,7 +53,7 @@
 # END
 
 - name: Start minio
-  shell: "nohup minio server /home/{{ ansible_user }}/minio --console-address :9090 >/dev/null 2>&1 &"
+  shell: "nohup /usr/local/bin/minio server /home/{{ ansible_user }}/minio --console-address :9090 >/dev/null 2>&1 &"
 
 - name: Download minio-client
   get_url:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes minio server deployment issue for the Kasten workload

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
Roles OCP Workloads - OCP4 Workload - Kasten - Pre Workload

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

The Minio server was not starting on the bastion host.  Added the full path to the minio binary within the automation

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
